### PR TITLE
[bug] override build with submodules

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,10 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+desc 'Override our build task to ensure methodologies git submodules are present'
+task 'build' do
+  submodule_status = `git submodule init && git submodule update`
+
+  raise 'git submodules were not up-to-date. Please rebuild!' unless submodule_status.empty?
+end


### PR DESCRIPTION
# Description

When we build the gem we want make sure that the submodules are included as well

### To test
1. clone repo
2. `rake build`
3. you can see `lib/data/0.1/..` being there
