### PR TITLE
[BC-17787] bmt-ruby add caption and tools to items

### DIFF
--- a/lib/bmt/item.rb
+++ b/lib/bmt/item.rb
@@ -1,12 +1,14 @@
 module BMT
   class Item
-    attr_reader :key, :title, :description, :vrt_category, :step
+    attr_reader :key, :title, :caption, :description, :tools :vrt_category, :step
 
     def initialize(step:, attributes:)
       @step = step
       @key = attributes['key']
       @title = attributes['title']
+      @caption = attributes['caption']
       @description = attributes['description']
+      @tools = attributes['tools']
       @vrt_category = attributes['vrt_category']
     end
   end

--- a/lib/bmt/item.rb
+++ b/lib/bmt/item.rb
@@ -1,6 +1,6 @@
 module BMT
   class Item
-    attr_reader :key, :title, :caption, :description, :tools :vrt_category, :step
+    attr_reader :key, :title, :caption, :description, :tools, :vrt_category, :step
 
     def initialize(step:, attributes:)
       @step = step

--- a/lib/bmt/version.rb
+++ b/lib/bmt/version.rb
@@ -1,3 +1,3 @@
 module Bmt
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/spec/bmt/item_spec.rb
+++ b/spec/bmt/item_spec.rb
@@ -23,6 +23,8 @@ describe BMT::Item do
       expect(subject.key).to eq('marsupial')
       expect(subject.title).to be_a(String)
       expect(subject.description).to be_a(String)
+      expect(subject.caption).to be_a(String)
+      expect(subject.tools).to be_a(String)
       expect(subject.vrt_category).to be_a(String)
       expect(subject.step).to eq(step)
     end

--- a/spec/sample/2.1/methodologies/outback-animal-testing.json
+++ b/spec/sample/2.1/methodologies/outback-animal-testing.json
@@ -15,18 +15,24 @@
           {
             "key": "marsupial",
             "title": "Is it a marsupial?",
-            "description": "Marsupials are obviously mammalian and have a pouch on their underside",
+            "caption": "Marsupials are obviously mammalian and have a pouch on their underside",
+            "description": "Check for the pouch",
+            "tools": "Eyes",
             "vrt_category": "insecure_data_storage"
           },
           {
             "key": "diet",
             "title": "Make sure it eats eucalyptus",
-            "description": "Almost no other animal can eat eucaluptus leaves, so this is a good diagnostic"
+            "caption": "Almost no other animal can eat eucaluptus leaves, so this is a good diagnostic",
+            "description": "Take some eucalyptus branches, remove some leaves and try to feed the alleged koala",
+            "tools": "Leaves and Branches"
           },
           {
             "key": "behavior",
             "title": "Does it sleep the whole day?",
-            "description": "Usually sleeps on trees"
+            "caption": "Usually sleeps on trees",
+            "description": "The alleged Koala should sleep the whole day if provided a tree.",
+            "tools": "Trees, Dawn"
           }
         ]
       },


### PR DESCRIPTION
Ticket BC-17787

# Description

Adding support to `caption` and `tools` for `BMT::Item`

# Test

`bin/console`

```
methodology = BMT.find('website_testing')
step = methodology.steps.first
item = step.items.first
item.caption
item.description
item.tools
```

