### PR TITLE
[CHORE] Bump bmt version to 0.4.0

### DIFF
--- a/lib/bmt/version.rb
+++ b/lib/bmt/version.rb
@@ -1,3 +1,3 @@
 module Bmt
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end

--- a/lib/bmt/version.rb
+++ b/lib/bmt/version.rb
@@ -1,3 +1,3 @@
 module Bmt
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.4.0'.freeze
 end


### PR DESCRIPTION
# Description

The https://github.com/bugcrowd/bmt-ruby/pull/10 PR was merged.
But in order for crowdcontrol to show the taxonomies, BMT ruby version needs to be bumped, so the bundle picks up the new changes