### PR TITLE
Add ruby version to publish gem workflow

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.7.2
+    - name: Set up Ruby 2.7
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.7.2
+        ruby-version: 2.7.x
         bundler-cache: true
 
     - name: Publish to GPR

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby
+    - name: Set up Ruby 2.7.2
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: .ruby-version
+        ruby-version: 2.7.2
         bundler-cache: true
 
     - name: Publish to GPR
@@ -24,7 +24,7 @@ jobs:
           chmod 0600 $HOME/.gem/credentials
           printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
           gem build *.gemspec
-          gem push -V --key github --host https://rubygems.pkg.github.com/${OWNER} *.gem    
+          gem push -V --key github --host https://rubygems.pkg.github.com/${OWNER} *.gem
       env:
         GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
         OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
The ruby version for the publish-gem workflow fails to read from `.ruby-version` file.
Changing the workflow here to use the ruby version for `2.7.x`