### PR TITLE
[CE-611] - Bump the BMT gem with the new methodology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Added new methodology for mobile_android
 - Added new methodology for binaries
 - Added new methodology for network
+- Added new methodology for Api Testing
 
 ### Changed
 

--- a/lib/bmt/version.rb
+++ b/lib/bmt/version.rb
@@ -1,3 +1,3 @@
 module Bmt
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.5.0'.freeze
 end


### PR DESCRIPTION
# Description

Updating  https://github.com/bugcrowd/methodology-taxonomy to https://github.com/bugcrowd/methodology-taxonomy/commit/d3be88141ea09a434c3e2c4dd86c8412fd283a9d

# Testing steps
The methodology key is
1. `api_testing`

```
bin/console
```

```ruby
> BMT.find('api_testing')
1. Confirm you can see the json data for api methodology.
