### PR TITLE
bump to 0.5.1

### DIFF
--- a/lib/bmt/version.rb
+++ b/lib/bmt/version.rb
@@ -1,3 +1,3 @@
 module Bmt
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.5.1'.freeze
 end


### PR DESCRIPTION
# Description

Forgot to include the submodules on the 0.5.0 release and we cannot re-release the same version on rubygems.
