### PR TITLE
bump to 0.10.2 to fix current_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/)
 
+## [0.10.2] - 2026-02-20
+
+### Fixed
+- Fixed version sorting to use semantic versioning instead of lexicographic ordering (`Gem::Version`), so that e.g. `0.10` correctly sorts above `0.9`
+
 ## [0.10.1] - 2026-02-20
 
 ### Fixed

--- a/bmt.gemspec
+++ b/bmt.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.files         = Dir['lib/**/*.{rb,json}']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.4'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.metadata = {
     'homepage_uri' => 'https://github.com/bugcrowd/bmt-ruby',

--- a/bmt.gemspec
+++ b/bmt.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.files         = Dir['lib/**/*.{rb,json}']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.1'
+  spec.required_ruby_version = '>= 3.4'
 
   spec.metadata = {
     'homepage_uri' => 'https://github.com/bugcrowd/bmt-ruby',

--- a/lib/bmt.rb
+++ b/lib/bmt.rb
@@ -71,6 +71,6 @@ module BMT
             .map(&:to_s)
             # START Contributions by Cursor.
             .grep(/^[0-9]+\.[0-9]/)
-            # END Cursor.
+    # END Cursor.
   end
 end

--- a/lib/bmt.rb
+++ b/lib/bmt.rb
@@ -51,7 +51,9 @@ module BMT
   # in the repo.
   # The returned list is in order with the current version first.
   def versions
-    @versions ||= json_dir_names.sort.reverse!
+    # START Contributions by Cursor.
+    @versions ||= json_dir_names.sort_by { |v| Gem::Version.new(v) }.reverse!
+    # END Cursor.
   end
 
   def methodology_json(key, version: current_version)
@@ -67,6 +69,8 @@ module BMT
     DATA_DIR.entries
             .map(&:basename)
             .map(&:to_s)
-            .grep(/^[0-9]+\.[0-9]/).sort
+            # START Contributions by Cursor.
+            .grep(/^[0-9]+\.[0-9]/)
+            # END Cursor.
   end
 end

--- a/lib/bmt/version.rb
+++ b/lib/bmt/version.rb
@@ -1,5 +1,5 @@
 module Bmt
   # START Contributions by Cursor.
-  VERSION = '0.10.1'.freeze
+  VERSION = '0.10.2'.freeze
   # END Cursor.
 end

--- a/spec/bmt_spec.rb
+++ b/spec/bmt_spec.rb
@@ -15,7 +15,7 @@ describe BMT do
     subject { described_class.current_version }
 
     it 'return the most recent version number for the vrt' do
-      expect(subject).to eq('2.1')
+      expect(subject).to eq('10.0')
     end
   end
 

--- a/spec/bmt_spec.rb
+++ b/spec/bmt_spec.rb
@@ -4,9 +4,11 @@ describe BMT do
   describe '#versions' do
     subject { described_class.versions }
 
+    # START Contributions by Cursor.
     it 'return all of the versions in the filesystem in reverse semver order' do
-      expect(subject).to eq(['2.1', '1.0'])
+      expect(subject).to eq(['10.0', '2.1', '1.0'])
     end
+    # END Cursor.
   end
 
   describe '#current_version' do

--- a/spec/sample/10.0/methodologies/outback-animal-testing.json
+++ b/spec/sample/10.0/methodologies/outback-animal-testing.json
@@ -1,0 +1,71 @@
+{
+  "metadata": {
+    "title": "The Outback Animal Checklist",
+    "release_date": "2021-05-31T00:00:00+00:00",
+    "description": "The right way to make sure you have the right Australian animals",
+    "vrt_version": "10.0.1"
+  },
+  "content": {
+    "steps": [
+      {
+        "key": "koala",
+        "title": "Check that you have a Koala",
+        "description": "# Does it look like one?\nIt is easy to find out.\n",
+        "type": "checklist",
+        "items": [
+          {
+            "key": "marsupial",
+            "title": "Is it a marsupial?",
+            "caption": "Marsupials are obviously mammalian and have a pouch on their underside",
+            "description": "Check for the pouch",
+            "tools": "Eyes",
+            "vrt_category": "insecure_data_storage"
+          },
+          {
+            "key": "diet",
+            "title": "Make sure it eats eucalyptus",
+            "caption": "Almost no other animal can eat eucaluptus leaves, so this is a good diagnostic",
+            "description": "Take some eucalyptus branches, remove some leaves and try to feed the alleged koala",
+            "tools": "Leaves and Branches"
+          },
+          {
+            "key": "behavior",
+            "title": "Does it sleep the whole day?",
+            "caption": "Usually sleeps on trees",
+            "description": "The alleged Koala should sleep the whole day if provided a tree.",
+            "tools": "Trees, Dawn"
+          }
+        ]
+      },
+      {
+        "key": "kangaroo",
+        "title": "Ensure you have a kangaroo",
+        "description": "Does it look like one?",
+        "type": "checklist",
+        "items": [
+          {
+            "key": "marsupial",
+            "title": "Is it a marsupial?",
+            "description": "Marsupials are obviously mammalian but possess a pouch on their underside"
+          },
+          {
+            "key": "tail",
+            "title": "Does it have a long tail?",
+            "description": "Kangaroos use their thick tail as a balance when jumping, and can use it as a support to rear up on when kicking"
+          },
+          {
+            "key": "jump",
+            "title": "Does it jump around?",
+            "description": "Over very short distances kangaroos will use their forepaws to balance on the ground and swing their legs forward. For longer distance movement, their jumping locomotion is unmistakeable."
+          }
+        ]
+      },
+      {
+        "key": "executive_summary",
+        "title": "Executive summary",
+        "description": "The executive summary should be written with a high-level view of both risk and business impact. It should be concise and clear, therefore it is important to use plain English. This ensures that non-technical readers can gain insight into security concerns outlined in your report.",
+        "type": "executive_summary"
+      }
+    ]
+  }
+}

--- a/spec/sample/10.0/methodologies/website-testing.json
+++ b/spec/sample/10.0/methodologies/website-testing.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "title": "Website Testing v10",
-    "release_date": "2026-02-20T00:00:00+00:00",
-    "description": "Placeholder methodology for version sorting test",
+    "title": "Bugcrowd Website Testing",
+    "release_date": "2021-06-15T00:00:00+00:00",
+    "description": "Bugcrowd Website Testing methodology",
     "vrt_version": "10.0.0"
   },
   "content": {
@@ -14,10 +14,24 @@
         "type": "checklist",
         "items": [
           {
-            "key": "search_engine_discovery",
-            "title": "Conduct Search Engine Discovery",
-            "description": "Placeholder item",
+            "key": "search_engine_discovery_and_reconnaissance",
+            "title": "Conduct Search Engine Discovery and Reconnaissance for Information Leakage",
+            "description": "OTG-INFO-001, WAHHM - Recon and Analysis",
             "vrt_category": "sensitive_data_exposure"
+          }
+        ]
+      },
+      {
+        "key": "config_and_deploy_management",
+        "title": "Configuration and Deploy Management Testing",
+        "description": "",
+        "type": "checklist",
+        "items": [
+          {
+            "key": "network_and_infrastructure",
+            "title": "Test Network/Infrastructure Configuration",
+            "description": "OTG-CONFIG-001, WAHHM - Recon and Analysis, Assess Application Hosting",
+            "vrt_category": "server_security_misconfiguration"
           }
         ]
       }

--- a/spec/sample/10.0/methodologies/website-testing.json
+++ b/spec/sample/10.0/methodologies/website-testing.json
@@ -1,0 +1,26 @@
+{
+  "metadata": {
+    "title": "Website Testing v10",
+    "release_date": "2026-02-20T00:00:00+00:00",
+    "description": "Placeholder methodology for version sorting test",
+    "vrt_version": "10.0.0"
+  },
+  "content": {
+    "steps": [
+      {
+        "key": "information",
+        "title": "Information gathering",
+        "description": "",
+        "type": "checklist",
+        "items": [
+          {
+            "key": "search_engine_discovery",
+            "title": "Conduct Search Engine Discovery",
+            "description": "Placeholder item",
+            "vrt_category": "sensitive_data_exposure"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## [0.10.2] - 2026-02-20

### Fixed
- Fixed version sorting to use semantic versioning instead of lexicographic ordering (`Gem::Version`), so that e.g. `0.10` correctly sorts above `0.9`


```ruby
[2] pry(main)> BMT.current_version
=> "0.10"
[3] pry(main)> BMT.versions
=> ["0.10", "0.9", "0.1"]
```